### PR TITLE
Handle Option[] parameters with no default.

### DIFF
--- a/derivation/src/main/scala/io/circe/magnolia/MagnoliaDecoder.scala
+++ b/derivation/src/main/scala/io/circe/magnolia/MagnoliaDecoder.scala
@@ -34,11 +34,11 @@ private[magnolia] object MagnoliaDecoder {
             val keyCursor = c.downField(key)
             keyCursor.focus match {
               case Some(json) => json.as[p.PType](p.typeclass)
-              case None => p.default.map { default => Right(default) }.getOrElse {
+              case None => p.default.fold(
                 // Some decoders (in particular, the default Option[T] decoder) do special things when a key is missing,
                 // so we give them a chance to do their thing here.
                 p.typeclass.tryDecode(keyCursor)
-              }
+              )(Right(_))
             }
           }
         }

--- a/derivation/src/main/scala/io/circe/magnolia/MagnoliaDecoder.scala
+++ b/derivation/src/main/scala/io/circe/magnolia/MagnoliaDecoder.scala
@@ -34,7 +34,11 @@ private[magnolia] object MagnoliaDecoder {
             val keyCursor = c.downField(key)
             keyCursor.focus match {
               case Some(json) => json.as[p.PType](p.typeclass)
-              case None => p.default.toRight(DecodingFailure("Attempt to decode value on failed cursor", keyCursor.history))
+              case None => p.default.map { default => Right(default) }.getOrElse {
+                // Some decoders (in particular, the default Option[T] decoder) do special things when a key is missing,
+                // so we give them a chance to do their thing here.
+                p.typeclass.tryDecode(keyCursor)
+              }
             }
           }
         }
@@ -43,11 +47,9 @@ private[magnolia] object MagnoliaDecoder {
     else {
       new Decoder[T] {
         def apply(c: HCursor): Result[T] = {
-          caseClass.constructMonadic(
-            p =>
-              c.downField(paramJsonKeyLookup.getOrElse(p.label, throw new IllegalStateException("Looking up a parameter label should always yield a value. This is a bug")))
-                .as[p.PType](p.typeclass)
-          )
+          caseClass.constructMonadic { p => 
+            p.typeclass.tryDecode(c.downField(paramJsonKeyLookup.getOrElse(p.label, throw new IllegalStateException("Looking up a parameter label should always yield a value. This is a bug"))))
+          }
         }
       }
     }

--- a/derivation/src/main/scala/io/circe/magnolia/MagnoliaDecoder.scala
+++ b/derivation/src/main/scala/io/circe/magnolia/MagnoliaDecoder.scala
@@ -34,11 +34,11 @@ private[magnolia] object MagnoliaDecoder {
             val keyCursor = c.downField(key)
             keyCursor.focus match {
               case Some(json) => json.as[p.PType](p.typeclass)
-              case None => p.default.fold(
+              case None => p.default.fold {
                 // Some decoders (in particular, the default Option[T] decoder) do special things when a key is missing,
                 // so we give them a chance to do their thing here.
                 p.typeclass.tryDecode(keyCursor)
-              )(Right(_))
+              }(Right(_))
             }
           }
         }

--- a/tests/src/main/scala/io/circe/tests/examples/package.scala
+++ b/tests/src/main/scala/io/circe/tests/examples/package.scala
@@ -179,7 +179,8 @@ package examples {
     required: String,
     field: String = "defaultValue",
     defaultOptSome: Option[String] = Some("defaultOptSome"),
-    defaultNone: Option[String] = None
+    defaultNone: Option[String] = None,
+    defaultOptNotSpecified: Option[String],
   )
 
   object ClassWithDefaults {
@@ -189,11 +190,13 @@ package examples {
       field <- Arbitrary.arbitrary[String]
       defaultOptSome <- Arbitrary.arbitrary[Option[String]]
       defaultNone <- Arbitrary.arbitrary[Option[String]]
+      defaultOptNotSpecified <- Arbitrary.arbitrary[Option[String]]
     } yield ClassWithDefaults(
       required = required,
       field = field,
       defaultOptSome = defaultOptSome,
-      defaultNone = defaultNone
+      defaultNone = defaultNone,
+      defaultOptNotSpecified = defaultOptNotSpecified,
     ))
   }
 

--- a/tests/src/test/scala/io/circe/magnolia/configured/ConfiguredSemiautoDerivedSuite.scala
+++ b/tests/src/test/scala/io/circe/magnolia/configured/ConfiguredSemiautoDerivedSuite.scala
@@ -145,7 +145,7 @@ class ConfiguredSemiautoDerivedSuite extends CirceSuite with Inside {
   "Configuration#useDefaults" should "Use the parameter default value if key does not exist in JSON" in {
     assert(
       WithDefaultValue
-        .decoder(parse("""{"required": "req"}""").right.get.hcursor) == Right(ClassWithDefaults(required = "req"))
+        .decoder(parse("""{"required": "req"}""").right.get.hcursor) == Right(ClassWithDefaults(required = "req", defaultOptNotSpecified = None))
     )
   }
 
@@ -156,15 +156,17 @@ class ConfiguredSemiautoDerivedSuite extends CirceSuite with Inside {
         "required": "req",
         "field": "provided",
         "defaultOptSome": "provided1",
-        "defaultNone": "provided2"
+        "defaultNone": "provided2",
+        "defaultOptNotSpecified": "provided3"
       }
     """).right.get
     val expected =
       ClassWithDefaults(
-        required       = "req",
-        field          = "provided",
-        defaultOptSome = Some("provided1"),
-        defaultNone    = Some("provided2")
+        required               = "req",
+        field                  = "provided",
+        defaultOptSome         = Some("provided1"),
+        defaultNone            = Some("provided2"),
+        defaultOptNotSpecified = Some("provided3"),
       )
     assert(WithDefaultValue.decoder(input.hcursor) == Right(expected))
   }
@@ -176,7 +178,7 @@ class ConfiguredSemiautoDerivedSuite extends CirceSuite with Inside {
         "defaultOptSome": null
       }
     """).right.get
-    val expected = ClassWithDefaults(required = "req", defaultOptSome = None)
+    val expected = ClassWithDefaults(required = "req", defaultOptSome = None, defaultOptNotSpecified = None)
     assert(WithDefaultValue.decoder(input.hcursor) == Right(expected))
   }
 


### PR DESCRIPTION
Circe permits case class parameters of type `Option[T]` with no default specified to still be decoded (to `None`) when the parameter is missing. This PR brings circe-magnolia in line with this behavior.