### PR TITLE
preserve history in decoder

### DIFF
--- a/derivation/src/main/scala/io/circe/magnolia/MagnoliaDecoder.scala
+++ b/derivation/src/main/scala/io/circe/magnolia/MagnoliaDecoder.scala
@@ -32,7 +32,7 @@ private[magnolia] object MagnoliaDecoder {
             val key = paramJsonKeyLookup.getOrElse(p.label, throw new IllegalStateException("Looking up a parameter label should always yield a value. This is a bug"))
             val keyCursor = c.downField(key)
             keyCursor.focus match {
-              case Some(json) => p.typeclass.decodeJson(json)
+              case Some(_) => p.typeclass.tryDecode(keyCursor)
               case None => p.default.fold {
                 // Some decoders (in particular, the default Option[T] decoder) do special things when a key is missing,
                 // so we give them a chance to do their thing here.


### PR DESCRIPTION
This PR allows decoders to keep history when trying to decode.
Before, the history was swallowed when using the json upon which focus was made and resulted in useless kind of decoding failures such as : `Left(DecodingFailure(Boolean, List()))` which did not specify the field in error. 
This PR uses the `tryDecode` on the original cursor to keep history. 